### PR TITLE
AnnounceEntry: add method that returns current tracker status

### DIFF
--- a/src/main/java/com/frostwire/jlibtorrent/AnnounceEntry.java
+++ b/src/main/java/com/frostwire/jlibtorrent/AnnounceEntry.java
@@ -78,4 +78,23 @@ public final class AnnounceEntry {
     public short tier() {
         return e.getTier();
     }
+    
+    public Status status() {
+        if (e.getVerified() && e.is_working()) {
+            return Status.WORKING;
+        } else if ((e.getFails() == 0) && e.getUpdating()) {
+            return Status.UPDATING;
+        } else if (e.getFails() == 0) {
+            return Status.NOT_CONTACTED;
+        } else {
+            return Status.NOT_WORKING;
+        }
+    }
+    
+    public enum Status {
+        NOT_CONTACTED,
+        WORKING,
+        UPDATING,
+        NOT_WORKING
+    }
 }


### PR DESCRIPTION
Hello. I think it would be useful a small syntactic sugar, which returns current status of a tracker in human readable form on the basis of existing `announce_entry` methods.