### PR TITLE
[build/linux-desktop] remove ELF executable flag warning on libjlibtorrent.so

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,11 @@ before_install:
       sudo dpkg --force-all -i lib32stdc++-5-dev_5.2.1-22ubuntu2_amd64.deb;
     fi
 
+# linux desktop (x86,x86_64)
+  - if [[ $os_build == "linux" && ( $os_arch == "x86" || $os_arch == "x86_64" ) ]]; then
+      sudo apt-get install -qq execstack
+    fi
+
 # linux arm packages
   - if [[ $os_build == "linux" && $os_arch == "arm" ]]; then
       wget https://releases.linaro.org/components/toolchain/binaries/5.3-2016.02/arm-linux-gnueabihf/gcc-linaro-5.3-2016.02-x86_64_arm-linux-gnueabihf.tar.xz;

--- a/swig/config/linux-x86-config.jam
+++ b/swig/config/linux-x86-config.jam
@@ -15,4 +15,5 @@ using gcc : x86 : g++-5 :
       <linkflags>-m32
       <linkflags>-static-libstdc++
       <linkflags>-static-libgcc
+      <linkflags>-z noexecstack
       ;

--- a/swig/config/linux-x86_64-config.jam
+++ b/swig/config/linux-x86_64-config.jam
@@ -12,4 +12,5 @@ using gcc : x86_64 : g++-5 :
       <linkflags>-L$(OPENSSL_ROOT)/lib
       <linkflags>-static-libstdc++
       <linkflags>-static-libgcc
+      <linkflags>-z noexecstack
       ;


### PR DESCRIPTION
This is a patch to remove this warning by the OpenJDK Runtime Environment.

```
It's highly recommended that you fix the library with 'execstack -c <libfile>', or link it with '-z noexecstack'.
```

I tried the `execstack -c libjlibtorrent.so` option on the command line and the warning goes away, here I've done the other suggestion of passing the `-z noexecstack` linking option.

`execstack` does not come out of the box in ubuntu, therefore I had to add it on the .travis file.

I'm sending a pull request now to see if this triggers the remote build, as I don't see anything on my own repo/branch.