### PR TITLE
[enhancement-proposal ] sessionManager.trackTorrentStats(...)

### DIFF
--- a/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
+++ b/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
@@ -1038,6 +1038,9 @@ public class SessionManager {
         sb.append("&x.pe=" + hostAddress + ":" + port);
     }
 
+
+
+
     private void alertsLoop() {
         Runnable r = new Runnable() {
             @Override
@@ -1117,6 +1120,11 @@ public class SessionManager {
         Thread t = new Thread(r, "SessionManager-alertsLoop");
         t.setDaemon(true);
         t.start();
+
+    }
+
+    public TorrentStats trackStats(TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
+        return new TorrentStats(this, torrentHandle, samplingIntervalInMs, maxHistoryInMs);
     }
 
     public static final class MutableItem {
@@ -1131,4 +1139,5 @@ public class SessionManager {
         public final byte[] signature;
         public final long seq;
     }
+
 }

--- a/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
+++ b/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
@@ -1038,9 +1038,6 @@ public class SessionManager {
         sb.append("&x.pe=" + hostAddress + ":" + port);
     }
 
-
-
-
     private void alertsLoop() {
         Runnable r = new Runnable() {
             @Override
@@ -1120,7 +1117,6 @@ public class SessionManager {
         Thread t = new Thread(r, "SessionManager-alertsLoop");
         t.setDaemon(true);
         t.start();
-
     }
 
     public TorrentStats trackStats(TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
@@ -1139,5 +1135,4 @@ public class SessionManager {
         public final byte[] signature;
         public final long seq;
     }
-
 }

--- a/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
+++ b/src/main/java/com/frostwire/jlibtorrent/SessionManager.java
@@ -1119,7 +1119,7 @@ public class SessionManager {
         t.start();
     }
 
-    public TorrentStats trackStats(TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
+    public TorrentStats trackTorrentStats(TorrentHandle torrentHandle, long samplingIntervalInMs, long maxHistoryInMs) {
         return new TorrentStats(this, torrentHandle, samplingIntervalInMs, maxHistoryInMs);
     }
 

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -1,29 +1,127 @@
 package com.frostwire.jlibtorrent;
 
 import com.frostwire.jlibtorrent.alerts.StatsAlert;
+import com.frostwire.jlibtorrent.alerts.AlertType;
 import com.frostwire.jlibtorrent.swig.torrent_handle;
 import com.frostwire.jlibtorrent.swig.torrent_status;
+
+import com.frostwire.jlibtorrent.alerts.Alert;
+import com.frostwire.jlibtorrent.alerts.TorrentAlert;
+
+import java.security.InvalidParameterException;
 
 /**
  * @author gubatron
  * @author aldenml
  * @author haperlot
  */
+
 public final class TorrentStats {
 
-    private final torrent_handle th;
+    private final SessionManager sessionManager;
+    private final torrent_handle torrentHandle;
+    private final long samplingIntervalInMs;
+    private final int[] TYPES;
+    private final int MAX_SAMPLES;
+    private long tStart; //for collecting sampling interval time
+
     private final Series downloadRateSeries;
     private final Series uploadRateSeries;
-    private final int MAX_SAMPLES;
 
-    public TorrentStats(TorrentHandle th, long samplingIntervalInMs, long maxHistoryInMs) {
-        this.th = th.swig(); // working with the swig types is for better performance
+    public enum Metric {
+        UploadRate,
+        DownloadRate
+    }
+
+    public TorrentStats(final SessionManager sessionManager, TorrentHandle th, long samplingIntervalInMs, long maxHistoryInMs) {
+        this.sessionManager = sessionManager;
+        this.torrentHandle = th.swig(); // working with the swig types is for better performance
         this.MAX_SAMPLES = (int) (maxHistoryInMs / samplingIntervalInMs);
         this.downloadRateSeries = new Series(MAX_SAMPLES);
         this.uploadRateSeries = new Series(MAX_SAMPLES);
-        // TODO: more code here
-        throw new UnsupportedOperationException("to be implemented");
+        this.samplingIntervalInMs = samplingIntervalInMs;
+        this.tStart = System.currentTimeMillis();
+        this.TYPES = new int[]{AlertType.STATS.swig()};
+        startAlertListener();
+
     }
+
+    /**
+     * It will start the alert event listener, as soon as the sampling interval
+     * meets the requested time it will save the values on queues. If the queues
+     * reach max size denoted by the maxHistory time, they will poll() the head
+     * element, in our case the oldest inserted.
+     */
+    public void startAlertListener() {
+        sessionManager.addListener(new AlertListener() {
+            @Override
+            public int[] types() {
+                return TYPES;
+            }
+
+            @Override
+            public void alert(Alert<?> alert) {
+
+                //if not eq to the torrentHandle return.
+                if (!((TorrentAlert<?>) alert).handle().swig().op_eq(torrentHandle)) {
+                    return;
+                }
+
+                //if !paused, it will take both stats when uploading / downloading
+                final torrent_status status = torrentHandle.status();
+                if (status != null && !status.getPaused()) {
+
+                    //only true if samplingIntervalInMs
+                    if ((System.currentTimeMillis() - tStart) >= samplingIntervalInMs) {
+                        tStart = System.currentTimeMillis();
+
+                        //it will keep maxsize since extends form CircularArray
+                        downloadRateSeries.add(status.getDownload_rate());
+                        uploadRateSeries.add(status.getUpload_rate());
+
+                    }
+
+                }
+            }
+        });
+    }
+
+    /**
+     * Will return all available items on the queue, depending on the type selected
+     *
+     * @param type of metric data to retrieved
+     * @return all the elements tracked by the event listener limited by the maxHistory
+     * <p>
+     * NOTE: since you have to do java acrobatics to create a T[] and native datatypes can't
+     * be considered as generics, I'm naming this on purpose like this as a hint for future
+     * getFloatSamples, getBooleanSamples, getLongSamples methods.
+     */
+
+    public int[] getIntSamples(Metric type) {
+        if (type != Metric.DownloadRate && type != Metric.UploadRate) {
+            throw new InvalidParameterException("TorrentStats.getIntSamples(" + type.toString() + "). Invalid metric type passed, it is not a metric that tracks int samples.");
+        }
+
+        int[] results = new int[MAX_SAMPLES];
+
+        switch (type) {
+            case DownloadRate:
+                results = downloadRateSeries.getBufferCopy();
+                break;
+            case UploadRate:
+                results = uploadRateSeries.getBufferCopy();
+                break;
+        }
+
+        return results;
+    }
+
+    /**
+     * yet to be implemented a new subscription method that has nothing to do with the SessionManager
+     *
+     * @param metric
+     * @return
+     */
 
     public Series series(SeriesMetric metric) {
         switch (metric) {
@@ -36,16 +134,23 @@ public final class TorrentStats {
         }
     }
 
+    /**
+     * yet to be implemented a new subscription method that has nothing to do with the SessionManager
+     *
+     * @param alert
+     * @return
+     */
+
     public void update(StatsAlert alert) {
-        if (!alert.swig().getHandle().op_eq(th)) {
+        if (!alert.swig().getHandle().op_eq(torrentHandle)) {
             return; // not for us
         }
 
-        if (!th.is_valid()) {
+        if (!torrentHandle.is_valid()) {
             return; // nothing we can do here
         }
 
-        torrent_status st = th.status();
+        torrent_status st = torrentHandle.status();
 
         if (st.getPaused()) {
             return; // just return for now, yes, quick return
@@ -66,7 +171,5 @@ public final class TorrentStats {
         Series(int capacity) {
             super(capacity);
         }
-        //return empty queue is empty
-        return new int[limit];
     }
 }

--- a/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentStats.java
@@ -66,5 +66,7 @@ public final class TorrentStats {
         Series(int capacity) {
             super(capacity);
         }
+        //return empty queue is empty
+        return new int[limit];
     }
 }

--- a/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
+++ b/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
@@ -1,0 +1,54 @@
+package com.frostwire.jlibtorrent.demo;
+
+import com.frostwire.jlibtorrent.*;
+import com.frostwire.jlibtorrent.alerts.Alert;
+import com.frostwire.jlibtorrent.alerts.AlertType;
+import com.frostwire.jlibtorrent.alerts.BlockFinishedAlert;
+import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * @author haperlot
+ */
+public final class TorrentStatsTest {
+
+    public static void main(String[] args) throws Throwable {
+
+        // comment this line for a real application
+        args = new String[]{"/Users/maximiliamgierschmann/Downloads/Honey_Larochelle_Hijack_FrostClick_FrostWire_MP3_May_06_2016.torrent"};
+        File torrentFile = new File(args[0]);
+
+        final SessionManager sessionManager = new SessionManager();
+        final CountDownLatch signal = new CountDownLatch(1);
+
+        long samplingIntervalInMs = 1000; // 1 second
+        long maxHistoryInMs = 10*60*1000; // 10 minutes
+
+        //starting sessionManager & torrent download
+        sessionManager.start();
+        TorrentInfo ti = new TorrentInfo(torrentFile);
+        sessionManager.download(ti, torrentFile.getParentFile());
+
+
+        //getting the torrentHandle for the TorrentStats tracker
+        TorrentHandle torrentHandle = sessionManager.find(ti.infoHash());
+        // This creates a new TorrentStatsKeeper instance and all the internal alert listeners necessary
+        TorrentStats stats = sessionManager.trackStats(torrentHandle, samplingIntervalInMs, maxHistoryInMs);
+        // gets all the available upload speed samples (bytes/sec), in this case that'd be <= 600 elements
+        // int[] uploadSpeeds = sessionManager.get(TorrentStats.Upload);
+        // gets the last 10 available download speed samples or less if less available
+        //int[] last10DownloadSpeedSamples = stas.get(TorrentStats.Download, 10);
+
+
+        //stoping  sessionManager & torrent download
+        signal.await();
+        sessionManager.stop();
+
+
+    }
+
+
+}

--- a/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
+++ b/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
@@ -65,9 +65,9 @@ public final class TorrentStatsTest {
                 }
 
                 //gets all the available upload speed samples (bytes/sec), in this case that'd be <= 600 elements
-                int[] speedRate = stats.get(TorrentStats.Metric.DownloadRate, 15);
+                int[] speedRate = stats.getIntSamples(TorrentStats.Metric.DownloadRate);
                 if (!torrentHandle.status().isFinished()) {
-                    for (int i = 0; i < speedRate.length; i++) System.out.print(speedRate[i] + " ");
+                    for (int aSpeedRate : speedRate) System.out.print(aSpeedRate + " ");
                 }
                 System.out.println(" ");
             }

--- a/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
+++ b/src/test/java/com/frostwire/jlibtorrent/demo/TorrentStatsTest.java
@@ -1,17 +1,16 @@
 package com.frostwire.jlibtorrent.demo;
-
 import com.frostwire.jlibtorrent.*;
 import com.frostwire.jlibtorrent.alerts.Alert;
 import com.frostwire.jlibtorrent.alerts.AlertType;
-import com.frostwire.jlibtorrent.alerts.BlockFinishedAlert;
 import com.frostwire.jlibtorrent.alerts.TorrentAddedAlert;
-
 import java.io.File;
-import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 
 /**
  * @author haperlot
+ *
+ * @samplingIntervalInMs the sampling interval time in milliseconds
+ * @maxHistoryInMs max history in milliseconds to be tracked
  */
 public final class TorrentStatsTest {
 
@@ -19,29 +18,25 @@ public final class TorrentStatsTest {
 
         // comment this line for a real application
         args = new String[]{"/Users/maximiliamgierschmann/Downloads/Honey_Larochelle_Hijack_FrostClick_FrostWire_MP3_May_06_2016.torrent"};
-        //args = new String[]{"/Users/maximiliamgierschmann/Downloads/47889789802D66F326A3B3238DF29BD891CEF493.torrent"};
-
         File torrentFile = new File(args[0]);
-
         final SessionManager sessionManager = new SessionManager();
         final CountDownLatch signal = new CountDownLatch(1);
-
-        long samplingIntervalInMs = 500; // 0.5 second
-        long maxHistoryInMs = 1 * 60 * 1000; // 1 minutes
 
         //starting sessionManager & torrent download
         sessionManager.start();
         TorrentInfo ti = new TorrentInfo(torrentFile);
         sessionManager.download(ti, torrentFile.getParentFile());
 
-
         //getting the torrentHandle for the TorrentStats tracker
         final TorrentHandle torrentHandle = sessionManager.find(ti.infoHash());
+
+        long samplingIntervalInMs = 500; // 0.5 second
+        long maxHistoryInMs = 1 * 60 * 1000; // 1 minutes
+
         // This creates a new TorrentStatsKeeper instance and all the internal alert listeners necessary
         final TorrentStats stats = sessionManager.trackStats(torrentHandle, samplingIntervalInMs, maxHistoryInMs);
 
-
-        //deckaring listener to check updated values
+        //declaring listener to check updated values
         sessionManager.addListener(new AlertListener() {
             @Override
             public int[] types() {
@@ -54,15 +49,17 @@ public final class TorrentStatsTest {
 
                 switch (type) {
 
+                    case TORRENT_ADDED:
+                        System.out.println("Torrent added ");
+                        ((TorrentAddedAlert) alert).handle().resume();
+
                     case BLOCK_FINISHED:
-                        // gets all the available upload speed samples (bytes/sec), in this case that'd be <= 600 elements
+                        //gets all the available upload speed samples (bytes/sec), in this case that'd be <= 600 elements
                         //int[] speedRate = stats.get(TorrentStats.DOWNLOAD);
-
-                        // gets the last 10 available download speed samples or less if less available
-                        int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 10);
+                        //gets the last 10 available download speed samples or less if less available
+                        //int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 10);
                         //int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 1);
-                        //int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 5);
-
+                        int[] speedRate = stats.get(TorrentStats.DOWNLOAD, 5);
                         System.out.println("Speeds(bytes/sec)");
                         if (!torrentHandle.status().isFinished())
                             for (int i = 0; i < speedRate.length; i++) System.out.print(speedRate[i] + " ");
@@ -71,13 +68,8 @@ public final class TorrentStatsTest {
                 }
             }
         });
-
-        //stoping  sessionManager & torrent download
+        //stop sessionManager
         signal.await();
         sessionManager.stop();
-
-
     }
-
-
 }


### PR DESCRIPTION
Created the class the keeps the track of the download/upload speeds, following: 
https://github.com/frostwire/frostwire-jlibtorrent/issues/137#issuecomment-267513564

there's still some place for improvement,  the collection interval time depends on how fast the alert event listener can retrieve the values. It can be done as fast as half a second for a single torrent downloading. The data is only tracked limited by the max history and stored on queues and returned in an array of int[] as specified on the requirement. 


