### PR TITLE
do not try to get a status on an invalid handle

### DIFF
--- a/src/main/java/com/frostwire/jlibtorrent/TorrentHandle.java
+++ b/src/main/java/com/frostwire/jlibtorrent/TorrentHandle.java
@@ -190,7 +190,7 @@ public final class TorrentHandle {
      */
     public TorrentStatus status(boolean force) {
         long now = System.currentTimeMillis();
-        if (force || (now - lastStatusRequestTime) >= REQUEST_STATUS_RESOLUTION_MILLIS) {
+        if (th.is_valid() && (force || (now - lastStatusRequestTime) >= REQUEST_STATUS_RESOLUTION_MILLIS)) {
             lastStatusRequestTime = now;
             lastStatus = new TorrentStatus(th.status(0));
         }


### PR DESCRIPTION
To avoid this crash:
```
java.lang.RuntimeException: invalid torrent handle used
	at com.frostwire.jlibtorrent.swig.libtorrent_jni.torrent_handle_status__SWIG_0(Native Method)
	at com.frostwire.jlibtorrent.swig.torrent_handle.status(torrent_handle.java:51)
	at com.frostwire.jlibtorrent.TorrentHandle.status(TorrentHandle.java:195)
	at com.frostwire.jlibtorrent.TorrentHandle.status(TorrentHandle.java:213)
	at com.frostwire.bittorrent.BTDownload.getDownloadSpeed(BTDownload.java:284)
```