### PR TITLE
Temporary fixing of Maven URL for getting latest JAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Develop libtorrent based apps with the joy of coding in Java.
 Using
 ========
 
-Download [the latest JAR](https://search.maven.org/remote_content?g=com.frostwire&a=jlibtorrent&v=LATEST) or get the dependency via Maven:
+Download [the latest JAR](https://search.maven.org/classic/remote_content?g=com.frostwire&a=jlibtorrent&v=LATEST) or get the dependency via Maven:
 ```xml
 <dependency>
   <groupId>com.frostwire</groupId>


### PR DESCRIPTION
Hi. Since recently the Maven site has been updated and many features have been corrupted, including a link to the latest JAR. So far there is a classic version of the site that supports the old behavior.